### PR TITLE
Fix another bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/dataloaders/helpers.py
+++ b/dataloaders/helpers.py
@@ -99,8 +99,6 @@ def load_rotten_tomatoes(
     dataset = prepare_dataset_with_elmo_tokenizer(dataset=dataset, text_columns=['text'], max_length=max_length)
     # TODO: support arbitrary tokenizer (for any model)
     train_dataset, test_dataset = dataset['train'], dataset['test'] # rt also has a 'validation' set
-    
-    print('Loading rotten tomatoes dataset with', num_examples, 'examples')
 
     train_dataset.set_format(type='torch', columns=['text', 'label'])
     test_dataset.set_format(type='torch', columns=['text', 'label'])

--- a/dataloaders/helpers.py
+++ b/dataloaders/helpers.py
@@ -108,7 +108,7 @@ def load_rotten_tomatoes(
         batch_size=batch_size, shuffle=True, drop_last=drop_last
     )
     test_dataloader = dataloader_from_dataset(
-        train_dataset, text_columns=['text'], label_columns=['label'],
+        test_dataset, text_columns=['text'], label_columns=['label'],
         batch_size=batch_size, shuffle=True, drop_last=drop_last
     )
     return train_dataloader, test_dataloader

--- a/dataloaders/paraphrase_dataset.py
+++ b/dataloaders/paraphrase_dataset.py
@@ -29,7 +29,7 @@ PUNC = '!"#$%&()*+,-./:;<=>?@[\\]^_`{|}~—“”'
 
 class ParaphraseDatasetBert(Dataset):
     def __init__(self, para_dataset: str = 'quora', model_name: str = 'bert-base-uncased', 
-                 num_examples: int = 25000, max_length: int = 40, stop_words_file: str = 'stop_words_en.txt',
+                 num_examples: int = None, max_length: int = 40, stop_words_file: str = 'stop_words_en.txt',
                  r1: float=0.5, seed: int = None):
         
         self.para_dataset = para_dataset
@@ -103,7 +103,7 @@ class ParaphraseDatasetBert(Dataset):
             # TODO: Tokenize things beforehand!
             for pair in quora_shuffled['train']:
                 #count += 1 #TODO incrementing here means you don't actually get 20k examples. It's what Shi did.
-                if count >= self.num_examples:
+                if (self.num_examples is not None) and count >= self.num_examples:
                     break
                 label = pair['is_duplicate']
                 s1_id = pair['questions']['id'][0]

--- a/experiment.py
+++ b/experiment.py
@@ -223,6 +223,8 @@ class FinetuneExperiment(Experiment):
     def __init__(self, args: argparse.Namespace):
         assert args.model_name in {"elmo_single_sentence", "elmo_sentence_pair"} # TODO: Support choice of model via argparse.
         self.args = args
+
+        # TODO: how to handle req_grad_elmo args during fine-tuning? Shouldn't ELMO never be frozen?
         self.model = (
             ElmoClassifier(
                 num_output_representations = 1, 
@@ -242,6 +244,11 @@ class FinetuneExperiment(Experiment):
         }
     
     def get_dataloaders(self) -> Tuple[DataLoader, DataLoader]:
+        logger.warn('Loading a fine-tuning dataset with a pre-defined test set so ignoring --train_test_split arg if set.')
+
+        if args.num_examples:
+            logger.warn('--num_examples set so restricting dataset sizes to %d', args.num_examples)
+
         if self.args.dataset_name == 'qqp':
             train_dataloader, test_dataloader = load_qqp(
                 max_length=self.args.max_length, batch_size=self.args.batch_size,

--- a/experiment.py
+++ b/experiment.py
@@ -237,7 +237,7 @@ class FinetuneExperiment(Experiment):
         )
         self._loss_fn = torch.nn.BCEWithLogitsLoss()
         self.metric_averages = TensorRunningAverages()
-        self.metrics = [Accuracy, PrecisionRecallF1]
+        self.metrics = [Accuracy(), PrecisionRecallF1()]
     
     def get_dataloaders(self) -> Tuple[DataLoader, DataLoader]:
         logger.warn('Loading a fine-tuning dataset with a pre-defined test set so ignoring --train_test_split arg if set.')

--- a/experiment.py
+++ b/experiment.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader, Dataset
 
 from dataloaders import ParaphraseDatasetElmo
 from dataloaders.helpers import load_rotten_tomatoes, load_qqp, train_test_split
-from metrics import f1, accuracy, precision, recall
+from metrics import Metric, Accuracy, PrecisionRecallF1
 from models import ElmoClassifier, ElmoRetrofit
 from utils import TensorRunningAverages, log_wandb_histogram
 
@@ -21,7 +21,7 @@ Metric = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 class Experiment(abc.ABC):
     model: torch.nn.Module
     dataset: Dataset
-    metrics: Dict[str, Metric]
+    metrics: List[Metric]
     metric_averages: TensorRunningAverages
 
     @abc.abstractmethod
@@ -49,16 +49,22 @@ class Experiment(abc.ABC):
                 ...
             }
         """
-        metrics: Dict[str, float] = {}
+        all_metrics_dict: Dict[str, float] = {}
         # Compute running averages of metrics and store in a dict
         for name in sorted(self.metric_averages.keys()):
             val = self.metric_averages.get(name)
-            metrics[name] = val
+            all_metrics_dict[name] = val
             # todo(jxm): use `logging` package here
             logger.info('\t%s = %f', name, val)
-        # Clear all metrics and return the averages
+        # Clear all metric averages and return the averages
         self.metric_averages.clear_all()
-        return metrics
+
+        # Add metrics that can't be computed by simple averaging
+        # (accuracy, precision, f1...)
+        for metric in self.metrics:
+            all_metrics_dict = (all_metrics_dict | metric.compute())
+
+        return all_metrics_dict
     
     @abc.abstractmethod
     def get_dataloaders() -> Tuple[DataLoader, DataLoader]:
@@ -69,9 +75,8 @@ class Experiment(abc.ABC):
 class RetrofitExperiment(Experiment):
     """Configures experiments with retrofitting loss."""
     model: ElmoRetrofit
-    metrics: Dict[str, Metric]
+    metrics: List[Metric]
     metric_averages: TensorRunningAverages
-
 
     def __init__(self, args: argparse.Namespace):
         assert args.model_name == "elmo_single_sentence" # TODO: Support choice of model via argparse.
@@ -86,11 +91,9 @@ class RetrofitExperiment(Experiment):
         self.rf_lambda = self.args.rf_lambda
         self.rf_gamma = self.args.rf_gamma
         self.metric_averages = TensorRunningAverages()
-        # TODO: implement retrofit metrics
-        #   --> I think loss is all we need for retrofitting -js
-        self.metrics = {}
+        self.metrics = []
 
-        # NOTE(js): added lists to hold every individual pos_dist and neg_dist for wandb histogram
+        # Lists to store things over batch for histograms
         self.pos_dist_list = []
         self.neg_dist_list = []
         self.diff_dist_list = [] #pos_dist - neg_dist
@@ -164,7 +167,7 @@ class RetrofitExperiment(Experiment):
         loss = positive_pair_distance + gamma - negative_pair_distance
         assert loss.shape == (word_rep_pos_1.shape[0],) # ensure dimensions of loss is same as batch size.
         
-        # if model is training, create distance lists for creating 4x wandb.plot.histogram() per epoch
+        # If model is training, create distance lists for creating 4x wandb.plot.histogram() per epoch
         if self.model.training:
             self.pos_dist_list += positive_pair_distance.tolist()
             self.neg_dist_list += negative_pair_distance.tolist() 
@@ -193,7 +196,6 @@ class RetrofitExperiment(Experiment):
         L_o: orthogonality constraint on matrix transformation M
         L = L_h + lambda * L_o
         """
-        # TODO: how to get representations for each word? --> ANS(js): ElmoRetrofit.forward() outputs
         hinge_loss, pre_clamp_hinge_loss, pos_pair_distance, neg_pair_distance = self.retrofit_hinge_loss(
             word_rep_pos_1, word_rep_pos_2,
             word_rep_neg_1, word_rep_neg_2,
@@ -202,7 +204,6 @@ class RetrofitExperiment(Experiment):
         orth_loss = self.orthogonalization_loss(self.M)
         loss = hinge_loss + self.rf_lambda * orth_loss
         self.metric_averages.update(f'{metrics_key}/Loss', loss.item())
-        # NOTE(js): logging 3 additional metrics to troubleshoot loss
         self.metric_averages.update(f'{metrics_key}/Hinge_Loss', hinge_loss.item())
         self.metric_averages.update(f'{metrics_key}/Pre_Clamp_Hinge_Loss', pre_clamp_hinge_loss.item())
         self.metric_averages.update(f'{metrics_key}/Orthogonalization_Loss', orth_loss.item())
@@ -217,7 +218,7 @@ class FinetuneExperiment(Experiment):
     classification-based tasks like those from the GLUE benchmark.
     """
     model: ElmoClassifier
-    metrics: Dict[str, Metric]
+    metrics: List[Metric]
     metric_averages: TensorRunningAverages
 
     def __init__(self, args: argparse.Namespace):
@@ -236,12 +237,7 @@ class FinetuneExperiment(Experiment):
         )
         self._loss_fn = torch.nn.BCEWithLogitsLoss()
         self.metric_averages = TensorRunningAverages()
-        self.metrics = {
-            'F1': f1,
-            'Precision': precision,
-            'Recall': recall,
-            'Acc': accuracy,
-        }
+        self.metrics = [Accuracy, PrecisionRecallF1]
     
     def get_dataloaders(self) -> Tuple[DataLoader, DataLoader]:
         logger.warn('Loading a fine-tuning dataset with a pre-defined test set so ignoring --train_test_split arg if set.')
@@ -268,16 +264,20 @@ class FinetuneExperiment(Experiment):
     def compute_loss_and_update_metrics(self, preds: torch.Tensor, targets: torch.Tensor, metrics_key: str) -> torch.Tensor:
         """Computes loss. Updates running metric computations stored in `self.metric_averages`.
 
-        Returns loss.
+        Args:
+            preds (torch.Tensor): y_pred to use for loss computation
+            targets (torch.Tensor): y_true to use for loss computation
+            metric_key (str): prefix for storing metric, probably looks like 'Test' or 'Train'
+
+        Returns loss as float torch.Tensor of shape ().
         """
         assert preds.shape == targets.shape
         loss = self._loss_fn(preds, targets)
         self.metric_averages.update(f'{metrics_key}/Loss', loss.item())
         pred_classes = torch.sigmoid(preds.squeeze()).detach() # TODO should we round here for sure?
 
-        for metric_name, metric_func in self.metrics.items():
-            val = metric_func(pred_classes, targets)
-            self.metric_averages.update(f'{metrics_key}/{metric_name}', val)
+        for metric in self.metrics:
+            metric.update(metrics_key, preds, target)
 
         return loss
 

--- a/experiment.py
+++ b/experiment.py
@@ -280,8 +280,6 @@ class FinetuneExperiment(Experiment):
         assert preds.shape == targets.shape
         loss = self._loss_fn(preds, targets)
         self.metric_averages.update(f'{metrics_key}/Loss', loss.item())
-        pred_classes = torch.sigmoid(preds.squeeze()).detach() # TODO should we round here for sure?
-
         for metric in self.metrics:
             metric.update(metrics_key, preds, targets)
 

--- a/experiment.py
+++ b/experiment.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, List, Tuple
 import abc
 import argparse
 import functools
@@ -277,7 +277,7 @@ class FinetuneExperiment(Experiment):
         pred_classes = torch.sigmoid(preds.squeeze()).detach() # TODO should we round here for sure?
 
         for metric in self.metrics:
-            metric.update(metrics_key, preds, target)
+            metric.update(metrics_key, preds, targets)
 
         return loss
 

--- a/metrics.py
+++ b/metrics.py
@@ -24,7 +24,6 @@ class Metric(abc.ABC):
         raise NotImplementedError()
 
 
-glob_n=0
 class Accuracy(Metric):
     """The number of predictions for y_true that are 100% correct."""
     num_correct: collections.defaultdict

--- a/metrics.py
+++ b/metrics.py
@@ -24,6 +24,7 @@ class Metric(abc.ABC):
         raise NotImplementedError()
 
 
+glob_n=0
 class Accuracy(Metric):
     """The number of predictions for y_true that are 100% correct."""
     num_correct: collections.defaultdict

--- a/metrics.py
+++ b/metrics.py
@@ -1,27 +1,88 @@
+from typing import Dict
+
+import abc
+import collections
 import torch
 
-def accuracy(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
-    """The number of predictions for y_true that are 100% correct.
+
+@abc.abstractclass
+class Metric:
+    """A generic metric calculated over multiple batches."""
+    @abc.abstractmethod
+    def update(self, y_pred: torch.Tensor, y_true: torch.Tensor) -> None:
+        """Updates values from a single batch of y_pred and y_true."""
+        raise NotImplementedError()
+    
+    @abc.abstractmethod
+    def compute(self) -> torch.Tensor:
+        """Computes metric based on all the stored values from all the batches.
+        
+        Returns: Dict that looks like
+        {
+            'metric_key': metric (float torch.Tensor): the average metric of shape ()
+        }
+        """
+        raise NotImplementedError()
+
+
+class Accuracy(Metric):
+    """The number of predictions for y_true that are 100% correct."""
+    num_correct: collections.defaultdict
+    total: collections.defaultdict
+    total: int
+    def __init__(self):
+        self.num_correct = collections.defaultdict(lambda: 0)
+        self.total = collections.defaultdict(lambda: 0)
+
+    def update(self, key: str, y_pred: torch.Tensor, y_true: torch.Tensor) -> None:
+        assert y_pred.shape == y_true.shape
+        y_pred = torch.round(y_pred)
+        self.num_correct[key] += (y_true == y_pred).sum()
+        self.total[key] += len(y_pred)
+
+    def compute(self) -> Dict[str, torch.Tensor]:
+        metrics_dict = {}
+        for key in self.num_correct.keys():
+            y_pred = torch.round(y_pred)
+            metrics_dict[f'{key}/accuracy'] = (y_true == y_pred).sum() / len(y_pred)
+        self.num_correct.clear()
+        self.total.clear()
+        return metrics_dict
+
+
+class PrecisionRecallF1(Metric):
     """
-    y_pred = torch.round(y_pred)
-    return (y_true == y_pred).sum() / len(y_pred)
+    Precision: (True Positives) / (True Positives + False Positives)
+    Recall: (True Positives) / (True Positives + False Negatives)
+    F1: 2 * (Precision * Recall) / (Precision + Recall)
+    """
+    true_positives: collections.defaultdict
+    false_positives: collections.defaultdict
+    false_negatives: collections.defaultdict
+    def __init__(self):
+        self.true_positives = collections.defaultdict(lambda: 0)
+        self.false_positives = collections.defaultdict(lambda: 0)
+        self.false_negatives = collections.defaultdict(lambda: 0)
 
-def precision(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
-    """Precision: (True Positives) / (True Positives + False Positives)"""
-    y_pred = torch.round(y_pred)
-    true_positives = torch.sum(torch.logical_and((y_true == 1), (y_pred == 1)))
-    false_positives = torch.sum(torch.logical_and((y_true == 0), (y_pred == 1)))
-    return true_positives / (true_positives + false_positives)
+    def update(self, key: str, y_pred: torch.Tensor, y_true: torch.Tensor) -> None:
+        assert y_pred.shape == y_true.shape
+        y_pred = torch.round(y_pred)
+        self.true_positives[key] += torch.sum(torch.logical_and((y_true == 1), (y_pred == 1)))
+        self.false_positives[key] += torch.sum(torch.logical_and((y_true == 0), (y_pred == 1)))
+        self.false_negatives[key] += torch.sum(torch.logical_and((y_true == 1), (y_pred == 0)))
 
-def recall(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
-    """Recall: (True Positives) / (True Positives + False Negatives)"""
-    y_pred = torch.round(y_pred)
-    true_positives = torch.sum(torch.logical_and((y_true == 1), (y_pred == 1)))
-    false_negatives = torch.sum(torch.logical_and((y_true == 1), (y_pred == 0)))
-    return true_positives / (true_positives + false_negatives)
+    def compute(self) -> torch.Tensor:
+        metrics_dict = {}
+        for key in self.true_positives.keys():
+            p = self.true_positives / float(self.true_positives + self.false_positives)
+            r = self.true_positives / float(self.true_positives + self.false_negatives)
+            f1 = 2 * (p * r) / (p + r)
+            metrics_dict[f'{key}/precision'] = p
+            metrics_dict[f'{key}/recall'] = r
+            metrics_dict[f'{key}/f1'] = f1
 
-def f1(y_pred: torch.Tensor, y_true: torch.Tensor) -> torch.Tensor:
-    """F1: 2 * (Precision * Recall) / (Precision + Recall)"""
-    p = precision(y_pred, y_true)
-    r = recall(y_pred, y_true)
-    return 2 * (p * r) / (p + r)
+        self.true_positives.clear()
+        self.false_positives.clear()
+        self.false_negatives.clear()
+
+        return metrics_dict

--- a/models.py
+++ b/models.py
@@ -131,7 +131,7 @@ class ElmoClassifier(torch.nn.Module):
         x = self.relu(x)
         logits = self.linear2(x).squeeze()
         assert logits.shape == (B,)
-        return logits
+        return torch.sigmoid(logits)
     
 
 class ElmoRetrofit(torch.nn.Module):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,7 @@ import torch
 from dataloaders import ParaphraseDatasetBert, ParaphraseDatasetElmo
 from mosestokenizer import MosesTokenizer
 
-from dataloaders.helpers import load_rotten_tomatoes, train_test_split
+from dataloaders.helpers import load_rotten_tomatoes, load_qqp, train_test_split
 
 # Instantiate ParaphraseDataset class variants for BERT and ELMo
 
@@ -153,10 +153,29 @@ class TestQuoraElmo:
 class TestClassificationDatasets:
     def test_rotten_tomatoes_elmo(self):
         batch_size = 19
+        num_examples = 100
         max_length = 173
-        tokenizer = MosesTokenizer('en', no_escape=True) # TODO: support arbitrary tokenizer (for any model)
-        train_dataloader, test_dataloader = load_rotten_tomatoes(batch_size=batch_size, max_length=max_length)
+        train_dataloader, test_dataloader = load_rotten_tomatoes(
+            batch_size=batch_size, max_length=max_length,
+            num_examples=num_examples, drop_last=False 
+        )
         item = next(iter(train_dataloader))
         batch, labels = item
         assert batch.shape == (batch_size, max_length, 50)
         assert labels[0].item() in {0, 1}
+    
+    def test_qqp_elmo(self):
+        batch_size = 7
+        num_examples = 19
+        max_length = 173
+        train_dataloader, test_dataloader = load_qqp(
+            batch_size=batch_size, max_length=max_length,
+            num_examples=num_examples, drop_last=False
+        )
+        item = next(iter(train_dataloader))
+        s1, s2, labels = item
+        # Make sure sentences are the proper shape
+        assert s1.shape == (batch_size, max_length, 50)
+        assert s2.shape == (batch_size, max_length, 50)
+        # make sure all labels in batch are in {0, 1}
+        assert torch.logical_or(labels == 0, labels == 1).all()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -163,6 +163,19 @@ class TestClassificationDatasets:
         batch, labels = item
         assert batch.shape == (batch_size, max_length, 50)
         assert labels[0].item() in {0, 1}
+
+    def test_rotten_tomatoes_elmo_full(self):
+        # Loads the full RT dataset (num examples is None).
+        # Checks the length of both datasets.
+        batch_size = 1
+        max_length = 16
+        num_examples = None
+        train_dataloader, test_dataloader = load_rotten_tomatoes(
+            batch_size=batch_size, max_length=max_length,
+            num_examples=num_examples, drop_last=False 
+        )
+        assert len(train_dataloader) == 8530
+        assert len(test_dataloader) == 1066
     
     def test_qqp_elmo(self):
         batch_size = 7

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+
+from metrics import Accuracy, PrecisionRecallF1
+
+class TestMetrics:
+    def test_acc_half(self):
+        accuracy = Accuracy()
+        # these preds are both correct
+        pred1 = torch.tensor([0.8, 0.9], dtype=float)
+        true1 = torch.tensor([1, 1], dtype=float)
+        accuracy.update('train', pred1, true1)
+        # these preds are both wrong
+        pred2 = torch.tensor([0.2, 0.4], dtype=float)
+        true2 = torch.tensor([1, 1], dtype=float)
+        accuracy.update('train', pred2, true2)
+        # acc should be 0.5
+        metrics = accuracy.compute()
+        assert metrics == {
+            'train/accuracy': 0.5
+        }
+
+
+    def test_acc_multikey(self):
+        accuracy = Accuracy()
+        # these preds are 25% correct
+        pred1 = torch.tensor([0.8, 0.9, 0.7, 0.6], dtype=float)
+        true1 = torch.tensor([1, 0, 0, 0,], dtype=float)
+        accuracy.update('train', pred1, true1)
+        # these preds are 75% correct
+        pred2 = torch.tensor([0.2, 0.4, 0.1, 0.3], dtype=float)
+        true2 = torch.tensor([0, 1, 0, 0], dtype=float)
+        accuracy.update('test', pred2, true2)
+        # acc should be 0.5 for both keys
+        metrics = accuracy.compute()
+        assert metrics == {
+            'train/accuracy': 0.25,
+            'test/accuracy': 0.75
+        }
+    
+    def test_precision_recall_f1_one_and_zero(self):
+        pr_metric = PrecisionRecallF1()
+        # everything should be 1s here
+        pred1 = torch.tensor([1, 1, 1, 1], dtype=float)
+        true1 = torch.tensor([1, 1, 1, 1], dtype=float)
+        pr_metric.update('train', pred1, true1)
+        # and these are all wrong
+        pred2 = torch.tensor([0, 0, 0, 0], dtype=float)
+        true2 = torch.tensor([1, 1, 1, 1], dtype=float)
+        pr_metric.update('eval', pred2, true2)
+        
+        metrics = pr_metric.compute()
+        assert metrics == {
+            'train/precision': 1.0,
+            'train/recall': 1.0,
+            'train/f1': 1.0,
+            #######################
+            'eval/precision': 0.0,
+            'eval/recall': 0.0,
+            'eval/f1': 0.0,
+        }
+
+    
+    def test_precision_recall_f1(self):
+        pr_metric = PrecisionRecallF1()
+        # log data in two separate batches (important!)
+        # tp, fn, fn
+        pred1 = torch.tensor([0.9, 0.1, 0.2,], dtype=float)
+        true1 = torch.tensor([1.0, 1.0, 1.0], dtype=float)
+        pr_metric.update('train', pred1, true1)
+        # fp, tn, tp
+        pred2 = torch.tensor([ 0.8, 0.2, 0.7], dtype=float)
+        true2 = torch.tensor([0.0, 0.0, 1.0], dtype=float)
+        pr_metric.update('train', pred2, true2)
+
+        # precision = tp / (tp + fp) = 2 / 3 = 0.666
+        # recall = tp / (tp + fn) = 2 / 4 = 0.5
+        # f1 = 2 * (p * r) / (p + r) = 2 * (0.333) / (1.1666) = 4 / 7 = 0.2857
+        metrics = pr_metric.compute()
+        assert metrics == pytest.approx({
+            'train/precision': 2/3,
+            'train/recall': 2/4,
+            'train/f1': 4/7,
+        })

--- a/train.py
+++ b/train.py
@@ -123,13 +123,17 @@ def run_training_loop(args: argparse.Namespace) -> str:
     day = time.strftime(f'%Y-%m-%d-%H%M')
     exp_name = f'{args.experiment}_{args.model_name}_{day}'
     # WandB init and config (based on argument dictionaries in imports/globals cell)
+    config_dict = vars(args) | {
+        "train_dataloader_len": len(train_dataloader),
+        "test_dataloader_len": len(test_dataloader), 
+    }
     wandb.init(
         name=exp_name,
         project=os.environ.get('WANDB_PROJECT', 'rf-bert'),
         entity=os.environ.get('WANDB_ENTITY', 'jscuds'),
         tags=args.wandb_tags,
         notes=args.wandb_notes,
-        config=vars(args)
+        config=config_dict,
     )
 
     # Log to a file and stdout
@@ -203,9 +207,9 @@ def run_training_loop(args: argparse.Namespace) -> str:
                     raise ValueError(f'Expected batch of length 2 or 3, got {len(batch)}')
                 train_loss = experiment.compute_loss_and_update_metrics(preds, targets, 'Train')
             else:
-                sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
-                sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = sent1.to(device), sent2.to(device), nsent1.to(device), nsent2.to(device), token1.to(device), token2.to(device), ntoken1.to(device), ntoken2.to(device)
-                word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2)
+                # sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
+                batch = (t.to(device) for t in batch)
+                word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(*batch)
                 train_loss = experiment.compute_loss_and_update_metrics(word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Train')
             
             train_loss.backward()
@@ -233,13 +237,13 @@ def run_training_loop(args: argparse.Namespace) -> str:
                                 raise ValueError(f'Expected batch of length 2 or 3, got {len(batch)}')
                             experiment.compute_loss_and_update_metrics(preds, targets, 'Test')
                         else:
-                            sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
-                            sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = sent1.to(device), sent2.to(device), nsent1.to(device), nsent2.to(device), token1.to(device), token2.to(device), ntoken1.to(device), ntoken2.to(device)
-                            word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2) 
+                            # sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
+                            batch = (t.to(device) for t in batch)
+                            word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(*batch) 
                             experiment.compute_loss_and_update_metrics(word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Test')
                 # Compute metrics, log, and reset
-                metrics_dict = experiment.compute_and_reset_metrics(epoch)
-                wandb.log(metrics_dict)
+                metrics_dict = experiment.compute_and_reset_metrics(step, epoch)
+                wandb.log(metrics_dict, step=step)
                 # Set model back in train mode to resume training
                 experiment.model.train() 
             

--- a/train.py
+++ b/train.py
@@ -179,11 +179,8 @@ def run_training_loop(args: argparse.Namespace) -> str:
         raise ValueError(f'unsupported optimizer {args.optimizer}')
 
     # use wandb.watch() to track gradients
-    # watch_log_freq is setup to log every 10 batches: num_examples//batch_size//10
-    #    which means it will log gradients every `watch_log_freq` batches
-
-    watch_log_freq = round(len(train_dataloader) / args.batch_size / 10.0)
-    wandb.watch(experiment.model, log_freq=watch_log_freq)
+    # watch_log_freq is setup to log every 10 batches:
+    wandb.watch(experiment.model, log_freq=round(len(train_dataloader) / 10.0))
 
     log_interval = max(len(train_dataloader) // args.logs_per_epoch, 1)
     logger.info(f'Logging metrics every {log_interval} training steps')

--- a/train.py
+++ b/train.py
@@ -90,7 +90,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
     Returns:
         model_folder (str): folder with saved final model & checkpoints
     """
-    if args.batch_size > args.num_examples:
+    if (args.num_examples is not None) and (args.batch_size > args.num_examples):
         logger.warn("Batch size (%d) cannot be greater than num examples (%d), decreasing batch size", args.batch_size, args.num_examples)
         args.batch_size = args.num_examples
     
@@ -182,7 +182,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
     # watch_log_freq is setup to log every 10 batches: num_examples//batch_size//10
     #    which means it will log gradients every `watch_log_freq` batches
 
-    watch_log_freq = args.num_examples//args.batch_size//10
+    watch_log_freq = len(train_dataloader)//args.batch_size//10
     wandb.watch(experiment.model, log_freq=watch_log_freq)
 
     log_interval = max(len(train_dataloader) // args.logs_per_epoch, 1)

--- a/train.py
+++ b/train.py
@@ -104,7 +104,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
     # Distribute training across multiple GPUs
     if torch.cuda.device_count() > 1:
         print(f'torch.nn.DataParallel distributing training across {torch.cuda.device_count()} GPUs')
-        model = _CustomDataParallel(model)
+        experiment.model = torch.nn.DataParallel(experiment.model)
 
     #########################################################
     ################## DATASET & DATALOADER #################
@@ -216,7 +216,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
             optimizer.step()
             optimizer.zero_grad()
 
-            if step % log_interval == 0:
+            if (step + 1) % log_interval == 0:
                 logger.info(f"Running evaluation at step {step} in epoch {epoch} (logs_per_epoch = {args.logs_per_epoch})")
                 experiment.model.eval() # set model in eval mode for evaluation
                 # Compute eval metrics every `log_interval` batches

--- a/train.py
+++ b/train.py
@@ -39,7 +39,7 @@ def get_argparser() -> argparse.ArgumentParser:
         type=int, help='number of epochs between model saves')
     parser.add_argument('--logs_per_epoch', type=int, default=5,
         help='log metrics this number of times per epoch')
-    parser.add_argument('--num_examples', type=int, default=25_000,
+    parser.add_argument('--num_examples', type=int, default=None,
         help='number of training examples')
     parser.add_argument('--max_length', type=int, default=40,
         help='max length of each sequence for truncation')

--- a/utils.py
+++ b/utils.py
@@ -39,10 +39,17 @@ class TensorRunningAverages:
         for key in self._store_sum:
             self.clear(key)
 
-def log_wandb_histogram(list_of_values: list, description: str, epoch: int):
+def log_wandb_histogram(list_of_values: list, description: str, step: int, epoch: int):
     """Logs a histogram of `list_of_values` to W&B."""
     lower_description = '_'.join(description.lower().split())
     data = [[val] for val in list_of_values]
     table = wandb.Table(data=data, columns=[lower_description])
-    wandb.log({f'{lower_description}_epoch_{epoch+1}': wandb.plot.histogram(table,lower_description,
-                title=f"{description} Histogram, Epoch {epoch+1}")})
+    histogram = wandb.plot.histogram(
+        table, lower_description,
+        title=f"{description} Histogram, Epoch {epoch+1}"
+    )
+    wandb.log({
+            lower_description: histogram, 
+            epoch: epoch
+            }, step=step
+    )


### PR DESCRIPTION
Our metric computations were using the logits, not probabilities, in my previous pull request (sorry!). I think it's better to have the model return a probability distribution (i.e. `torch.sigmoid` on the outputs) and then handle everything as probabilities and not logits. So I had to change the loss function too.

An important note is that we've only set up fine-tuning for binary classification tasks like `rotten_tomatoes`! So if we want to fine-tune and test on a task that has >2 labels, we'll need to change the code a bit.