### PR TITLE
load test not train in attack.py

### DIFF
--- a/attack.py
+++ b/attack.py
@@ -23,9 +23,11 @@ device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 num_examples = 1000
 attack_in_parallel = False
 # I have one model saved that's just fine-tuned from scratch (with no M matrix):
-model_path, model_is_retrofitted = 'models/finetune_elmo_single_sentence_2022-02-15-1437/final.pth', False
+# model_path, model_is_retrofitted = 'models/finetune_elmo_single_sentence_2022-02-15-1437/final.pth', False
 # And I have another model that's fine-tuned after retrofitting:
 # model_path, model_is_retrofitted = 'models/finetune_elmo_single_sentence_2022-02-15-1457/final.pth', True
+
+model_path, model_is_retrofitted = 'models/finetune_elmo_2022-02-17-1226/final.pth', True
 
 class ElmoModelWrapper(textattack.models.wrappers.ModelWrapper):
     tokenizer: MosesTokenizer
@@ -65,7 +67,7 @@ def main():
     model_wrapper = ElmoModelWrapper(model)
 
     # Run attack
-    dataset = HuggingFaceDataset("rotten_tomatoes", "test")
+    dataset = HuggingFaceDataset("rotten_tomatoes", split="test")
     attack = TextFoolerJin2019.build(model_wrapper)
     attack_args = textattack.AttackArgs(
         num_examples=num_examples, parallel=attack_in_parallel


### PR DESCRIPTION
need the `split=` argument to load the test split instead of asking for  the test subset (which doesn't exist, but doesn't throw an error - see issue: https://github.com/huggingface/datasets/issues/3747)