### PR TITLE
W&B Tables to view sample of retrofit examples over time.

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -132,7 +132,7 @@ class RetrofitExperiment(Experiment):
             self.wb_table = (
                 TableLog(
                     num_table_examples=self.args.num_table_examples,
-                    columns=["epoch", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
+                    columns=["epoch", "index", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
                 )
             )
 

--- a/experiment.py
+++ b/experiment.py
@@ -156,7 +156,7 @@ class RetrofitExperiment(Experiment):
             word_rep_pos_1: torch.Tensor, word_rep_pos_2: torch.Tensor,
             word_rep_neg_1: torch.Tensor, word_rep_neg_2: torch.Tensor,
             gamma: float
-        ) -> torch.Tensor:
+        ) -> Tuple[torch.Tensor,torch.Tensor,torch.Tensor,torch.Tensor]:
         """L_H = sum_{w} [d_1(M w) - \gamma + d_2(M w)]_+
         
         Where d_1 is the distance between w's representations in a paraphrase pair (hopefully
@@ -167,8 +167,8 @@ class RetrofitExperiment(Experiment):
         """
         assert word_rep_pos_1.shape == word_rep_pos_2.shape
         assert word_rep_neg_1.shape == word_rep_neg_2.shape
-        positive_pair_distance = torch.norm(word_rep_pos_1 - word_rep_pos_2, p=2, dim=1) # TODO: need keepdim=True??
-        negative_pair_distance = torch.norm(word_rep_neg_1 - word_rep_neg_2, p=2, dim=1) # shape: (batch_size,) if keepdim=False
+        positive_pair_distance = torch.norm(word_rep_pos_1 - word_rep_pos_2, p=2, dim=-1) # NOTE(js) changed from dim=1 to dim=-1 to work with batch_size=1
+        negative_pair_distance = torch.norm(word_rep_neg_1 - word_rep_neg_2, p=2, dim=-1) # shape: (batch_size,) if keepdim=False
 
         loss = positive_pair_distance + gamma - negative_pair_distance
         assert loss.shape == (word_rep_pos_1.shape[0],) # ensure dimensions of loss is same as batch size.

--- a/tablelog.py
+++ b/tablelog.py
@@ -1,9 +1,6 @@
-import random
 from typing import Dict, List, Tuple
-
 import torch
 import wandb
-from torch.utils.data import DataLoader
 
 
 from utils import elmo_sentence_decode
@@ -11,110 +8,75 @@ from utils import elmo_sentence_decode
 class TableLog:
     """A class to log W&B tables for specific examples over each epoch of retrofitting."""
     
-    def __init__(self, num_table_examples: int, train_dataloader: DataLoader, test_dataloader: DataLoader, columns:List[str]):
+    def __init__(self, num_table_examples: int, columns:List[str]):
 
-        # Sample k examples from the indices in the train/test dataset, respectively
         self.num_table_examples: int = num_table_examples
-        self.table_train_indices: List[int] = random.sample(train_dataloader.sampler.indices, k=self.num_table_examples)
-        self.table_test_indices: List[int] = random.sample(test_dataloader.sampler.indices, k=self.num_table_examples)
-        self.id_to_sent: Dict[int, Tuple[Tuple[int,...],...]] = train_dataloader.dataset._id_to_sent # dict; lookup sentence given sentence_id
-        self.para_tuples: List[Tuple[int,int,int,int]] = train_dataloader.dataset._para_tuples # list of tuples; (s1_id, s2_id, idx1, idx2)
-        
+        self.train_epochs_sampled: List[int] = [] # store a list of epochs where a batch was sampled so only 1 batch is sampled per epoch
+        self.test_epochs_sampled: List[int] = [] # store a list of epochs where a batch was sampled so only 1 batch is sampled per epoch
+
         # self.final_table will be what is logged to W&B
         self.final_table = wandb.Table(columns=columns)
 
-        # For all dicts, key is the integer representing the positive example in the paraphrase dataset
-        #     ex. the return of quora[10]; 10 is the key for all dictionaries.  This keeps tracking the example
-        #         consistent across all epochs with batch shuffling.
-        self.batch_indices: Dict[int,int] = {}
-        self.table_split: Dict[int,str] = {} # 'train' or 'validation
-        self.table_pos_sent1: Dict[int, torch.Tensor] = {}
-        self.table_pos_sent2: Dict[int, torch.Tensor] = {}
-        self.table_pos_word1: Dict[int, int] = {}
-        self.table_pos_word2: Dict[int, int] = {}
-        self.table_pos_sent1_str: Dict[int, str] = {}
-        self.table_pos_sent2_str: Dict[int, str] = {}
-        self.table_neg_sent1_str: Dict[int, str] = {}
-        self.table_neg_sent2_str: Dict[int, str] = {}
-        self.table_neg_word1: Dict[int, int] = {} # TODO: remove?
-        self.table_neg_word2: Dict[int, int] = {} # TODO: remove?
-        self.table_pos_target_word: Dict[int, str] = {}
-        self.table_neg_target_word: Dict[int, str] = {}
-        self.table_pos_word_dist: Dict[int, float] = {}
-        self.table_neg_word_dist: Dict[int, float] = {}
-        self.table_hinge_loss: Dict[int, float] = {}
+        # For all dicts, key is the tuple `(epoch, index, split)``
+        #    where `index` is arbitrarily assigned `for i in range(num_table_examples)`
+        #    and   `split` is 'train' or 'validation' based on whether the model.training == True/False}
+        self.table_pos_sent1_str: Dict[Tuple[int,int,str], str] = {}
+        self.table_pos_sent2_str: Dict[Tuple[int,int,str], str] = {}
+        self.table_neg_sent1_str: Dict[Tuple[int,int,str], str] = {}
+        self.table_neg_sent2_str: Dict[Tuple[int,int,str], str] = {}
+        self.table_pos_target_word: Dict[Tuple[int,int,str], str] = {}
+        self.table_neg_target_word: Dict[Tuple[int,int,str], str] = {}
+        self.table_pos_word_dist: Dict[Tuple[int,int,str], float] = {}
+        self.table_neg_word_dist: Dict[Tuple[int,int,str], float] = {}
+        self.table_hinge_loss: Dict[Tuple[int,int,str], float] = {}
     
 
-    def get_tracked_examples(self) -> None:
-        """Get information for sampled examples.  Called after dataloaders instantiated and before the training loop."""
-        for i in self.table_train_indices: self.table_split[i] = 'train'
-        for i in self.table_test_indices: self.table_split[i] = 'validation'
-        
-        for i in (self.table_train_indices+self.table_test_indices): 
+    def get_sample_batch(self, epoch: int, model_training: bool, 
+                         pos_sent_1: torch.Tensor, pos_sent_2: torch.Tensor,
+                         neg_sent_1: torch.Tensor, neg_sent_2: torch.Tensor,
+                         pos_token_1: torch.Tensor, pos_token_2: torch.Tensor,
+                         neg_token_1: torch.Tensor, neg_token_2: torch.Tensor) -> None:
+        """ Get one batch of data and log `num_table_examples` of the batch in a W&B Table."""
 
-            # Pull sentence/overlap from dataset._para_tuples
-            pos_sent1, pos_sent2, token1, token2 = self.para_tuples[i] # (s1_id, s2_id, idx1, idx2)
-            pos_sent1, pos_sent2 = torch.tensor(self.id_to_sent[pos_sent1]), torch.tensor(self.id_to_sent[pos_sent2]) # convert sent_id to sentence tensor; shape: [40,50]
-            
-            pos_sent1_str, pos_sent2_str = elmo_sentence_decode(pos_sent1), elmo_sentence_decode(pos_sent2) # get string representations of sentence
+        # Get num_table_examples examples from batch
+        # NOTE: previously key of dictionary corresponded to a particular index of the dataset;
+        #     After refactoring, the key is just a tuple `(epoch, range(num_table_examples), split)``
+        if model_training: 
+            split='train'
+        else:
+            split='validation'
 
-            # populate dictionaries
-            self.table_pos_sent1[i] = pos_sent1
-            self.table_pos_sent2[i] = pos_sent2
-            self.table_pos_sent1_str[i] = pos_sent1_str
-            self.table_pos_sent2_str[i] = pos_sent2_str
-            self.table_pos_word1[i] = token1
-            self.table_pos_word2[i] = token2
-            assert pos_sent1_str.split(' ')[token1] == pos_sent2_str.split(' ')[token2] # assert that the word is the same in both pos_sent1 & pos_sent2
-            self.table_pos_target_word[i] = pos_sent1_str.split(' ')[token1]
+        for i in range(self.num_table_examples):
+            key = (epoch,i,split)
+            # Populate positive example dictionaries
+            self.table_pos_sent1_str[key], self.table_pos_sent2_str[key] = elmo_sentence_decode(pos_sent_1[i]), elmo_sentence_decode(pos_sent_2[i]) # get string representations of sentences
+            assert self.table_pos_sent1_str[key].split(' ')[pos_token_1[i].item()] == self.table_pos_sent2_str[key].split(' ')[pos_token_2[i].item()] # assert that the word is the same in both pos_sent1 & pos_sent2
+            self.table_pos_target_word[key] = self.table_pos_sent1_str[key].split(' ')[pos_token_1[i].item()]
 
-    def check_tracked_indices(self, pos_sent_1: torch.Tensor, pos_sent_2: torch.Tensor,
-                              neg_sent_1: torch.Tensor, neg_sent_2: torch.Tensor,
-                              pos_token_1: torch.Tensor, pos_token_2: torch.Tensor,
-                              neg_token_1: torch.Tensor, neg_token_2: torch.Tensor) -> Dict[int,int]:
-        """Given a retrofit batch, determine if any of the examples are the ones we are sampling for a W&B Table.  """
-        
-        # Reset self.batch_indices each time it's called
-        self.batch_indices = {}
-        batch_size = pos_sent_1.shape[0]
+            # Populate negative example dictionaries
+            self.table_neg_sent1_str[key], self.table_neg_sent2_str[key] = elmo_sentence_decode(neg_sent_1[i]), elmo_sentence_decode(neg_sent_2[i]) # get string representations of sentence 2
+            assert self.table_neg_sent1_str[key].split(' ')[neg_token_1[i].item()] == self.table_neg_sent2_str[key].split(' ')[neg_token_2[i].item()] # assert that the word is the same in both pos_sent1 & pos_sent2
+            self.table_neg_target_word[key] = self.table_neg_sent1_str[key].split(' ')[neg_token_1[i].item()]
 
-        # compare dictionary of sentences we're tracking to see if they're present in a batch.
-        for b in range(batch_size):
-            for i in self.table_pos_sent1.keys():
-                #  if sentence pair matches the paraphrase tuple, add batch_index as a value corresponding to the tracked_index key
-                if (torch.equal(self.table_pos_sent1[i], pos_sent_1[b]) and torch.equal(self.table_pos_sent2[i], pos_sent_2[b]) and 
-                    self.table_pos_word1[i] == pos_token_1[b].item() and self.table_pos_word2[i] == pos_token_2[b].item()):
 
-                    self.batch_indices[i] = b
-                    neg_sent1_str, neg_sent2_str = elmo_sentence_decode(neg_sent_1[b]), elmo_sentence_decode(neg_sent_2[b])
-                    self.table_neg_sent1_str[i] = neg_sent1_str
-                    self.table_neg_sent2_str[i] = neg_sent2_str
-                    self.table_neg_word1[i] = neg_token_1[b].item()
-                    self.table_neg_word2[i] = neg_token_2[b].item()
-                    assert neg_sent1_str.split(' ')[neg_token_1[b].item()] == neg_sent2_str.split(' ')[neg_token_2[b].item()] # assert that the word is the same in both pos_sent1 & pos_sent2
-                    self.table_neg_target_word[i] = neg_sent1_str.split(' ')[neg_token_1[b].item()]
-
-                else: continue
-
-        return self.batch_indices
-
-    def update_wandb_table(self, epoch:int) -> None:
-        """Update rows of example table at the end of each epoch."""
-        # columns ["index", "epoch", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
-        # columns [index, epoch, sent1, sent2, pos_word, positive, pos_distance, hinge_loss]
-        #         [index, epoch, sent1, sent2, neg_word, negative, neg_distance, hinge_loss] 
+    def update_wandb_table(self) -> None:
+        """Update rows of example table at the end of training."""
+        # columns ["epoch", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
+        # columns [epoch, positive, sent1, sent2, pos_word, pos_distance, hinge_loss, split]
+        #         [epoch, negative, sent1, sent2, neg_word, neg_distance, hinge_loss, split] 
         
         # Each example will have 2 rows: Row A = Positive, Row B = Negative
-        for i in sorted(self.table_split.keys()):
+        for epoch, i, split in sorted(self.table_pos_sent1_str.keys()):
+            key = (epoch,i,split)
             # Row A
             self.final_table.add_data(
-                i, epoch, 'positive', self.table_pos_sent1_str[i], self.table_pos_sent2_str[i],
-                self.table_pos_target_word[i], self.table_pos_word_dist[i],
-                self.table_hinge_loss[i], self.table_split[i]
+                epoch, 'positive', self.table_pos_sent1_str[key], self.table_pos_sent2_str[key],
+                self.table_pos_target_word[key], self.table_pos_word_dist[key],
+                self.table_hinge_loss[key], split
             )
             # Row B
             self.final_table.add_data(
-                i, epoch, 'negative', self.table_neg_sent1_str[i], self.table_neg_sent2_str[i],
-                self.table_neg_target_word[i], self.table_neg_word_dist[i],
-                self.table_hinge_loss[i], self.table_split[i]
+                i, epoch, 'negative', self.table_neg_sent1_str[key], self.table_neg_sent2_str[key],
+                self.table_neg_target_word[key], self.table_neg_word_dist[key],
+                self.table_hinge_loss[key], split
             )

--- a/tablelog.py
+++ b/tablelog.py
@@ -1,32 +1,20 @@
-import argparse
-import copy
-import glob
-import json
-import logging
-import os
 import random
-import shutil
-import time
-from pathlib import Path
 from typing import Dict, List, Tuple
 
-import numpy as np
-import pytest
 import torch
-import tqdm
 import wandb
 from torch.utils.data import DataLoader
 
 
 from utils import elmo_sentence_decode
 
-class TableLog():
+class TableLog:
     """A class to log W&B tables for specific examples over each epoch of retrofitting."""
     
-    def __init__(self, num_table_examples:int, train_dataloader: DataLoader, test_dataloader: DataLoader, columns:List[str]):
+    def __init__(self, num_table_examples: int, train_dataloader: DataLoader, test_dataloader: DataLoader, columns:List[str]):
 
         # Sample k examples from the indices in the train/test dataset, respectively
-        self.num_table_examples = num_table_examples
+        self.num_table_examples: int = num_table_examples
         self.table_train_indices: List[int] = random.sample(train_dataloader.sampler.indices, k=self.num_table_examples)
         self.table_test_indices: List[int] = random.sample(test_dataloader.sampler.indices, k=self.num_table_examples)
         self.id_to_sent: Dict[int, Tuple[Tuple[int,...],...]] = train_dataloader.dataset._id_to_sent # dict; lookup sentence given sentence_id
@@ -80,7 +68,6 @@ class TableLog():
             assert pos_sent1_str.split(' ')[token1] == pos_sent2_str.split(' ')[token2] # assert that the word is the same in both pos_sent1 & pos_sent2
             self.table_pos_target_word[i] = pos_sent1_str.split(' ')[token1]
 
-    # TODO: called every time a batch is passed in the train/val loop from the respective dataloader
     def check_tracked_indices(self, pos_sent_1: torch.Tensor, pos_sent_2: torch.Tensor,
                               neg_sent_1: torch.Tensor, neg_sent_2: torch.Tensor,
                               pos_token_1: torch.Tensor, pos_token_2: torch.Tensor,

--- a/tablelog.py
+++ b/tablelog.py
@@ -61,22 +61,22 @@ class TableLog:
 
     def update_wandb_table(self) -> None:
         """Update rows of example table at the end of training."""
-        # columns ["epoch", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
-        # columns [epoch, positive, sent1, sent2, pos_word, pos_distance, hinge_loss, split]
-        #         [epoch, negative, sent1, sent2, neg_word, neg_distance, hinge_loss, split] 
+        # columns ["epoch", "index", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
+        # columns [epoch, index, positive, sent1, sent2, pos_word, pos_distance, hinge_loss, split]
+        #         [epoch, index, negative, sent1, sent2, neg_word, neg_distance, hinge_loss, split] 
         
         # Each example will have 2 rows: Row A = Positive, Row B = Negative
         for epoch, i, split in sorted(self.table_pos_sent1_str.keys()):
             key = (epoch,i,split)
             # Row A
             self.final_table.add_data(
-                epoch, 'positive', self.table_pos_sent1_str[key], self.table_pos_sent2_str[key],
+                epoch, i, 'positive', self.table_pos_sent1_str[key], self.table_pos_sent2_str[key],
                 self.table_pos_target_word[key], self.table_pos_word_dist[key],
                 self.table_hinge_loss[key], split
             )
             # Row B
             self.final_table.add_data(
-                i, epoch, 'negative', self.table_neg_sent1_str[key], self.table_neg_sent2_str[key],
+                epoch, i, 'negative', self.table_neg_sent1_str[key], self.table_neg_sent2_str[key],
                 self.table_neg_target_word[key], self.table_neg_word_dist[key],
                 self.table_hinge_loss[key], split
             )

--- a/tablelog.py
+++ b/tablelog.py
@@ -1,0 +1,133 @@
+import argparse
+import copy
+import glob
+import json
+import logging
+import os
+import random
+import shutil
+import time
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pytest
+import torch
+import tqdm
+import wandb
+from torch.utils.data import DataLoader
+
+
+from utils import elmo_sentence_decode
+
+class TableLog():
+    """A class to log W&B tables for specific examples over each epoch of retrofitting."""
+    
+    def __init__(self, num_table_examples:int, train_dataloader: DataLoader, test_dataloader: DataLoader, columns:List[str]):
+
+        # Sample k examples from the indices in the train/test dataset, respectively
+        self.num_table_examples = num_table_examples
+        self.table_train_indices: List[int] = random.sample(train_dataloader.sampler.indices, k=self.num_table_examples)
+        self.table_test_indices: List[int] = random.sample(test_dataloader.sampler.indices, k=self.num_table_examples)
+        self.id_to_sent: Dict[int, Tuple[Tuple[int,...],...]] = train_dataloader.dataset._id_to_sent # dict; lookup sentence given sentence_id
+        self.para_tuples: List[Tuple[int,int,int,int]] = train_dataloader.dataset._para_tuples # list of tuples; (s1_id, s2_id, idx1, idx2)
+        
+        # self.final_table will be what is logged to W&B
+        self.final_table = wandb.Table(columns=columns)
+
+        # For all dicts, key is the integer representing the positive example in the paraphrase dataset
+        #     ex. the return of quora[10]; 10 is the key for all dictionaries.  This keeps tracking the example
+        #         consistent across all epochs with batch shuffling.
+        self.batch_indices: Dict[int,int] = {}
+        self.table_split: Dict[int,str] = {} # 'train' or 'validation
+        self.table_pos_sent1: Dict[int, torch.Tensor] = {}
+        self.table_pos_sent2: Dict[int, torch.Tensor] = {}
+        self.table_pos_word1: Dict[int, int] = {}
+        self.table_pos_word2: Dict[int, int] = {}
+        self.table_pos_sent1_str: Dict[int, str] = {}
+        self.table_pos_sent2_str: Dict[int, str] = {}
+        self.table_neg_sent1_str: Dict[int, str] = {}
+        self.table_neg_sent2_str: Dict[int, str] = {}
+        self.table_neg_word1: Dict[int, int] = {} # TODO: remove?
+        self.table_neg_word2: Dict[int, int] = {} # TODO: remove?
+        self.table_pos_target_word: Dict[int, str] = {}
+        self.table_neg_target_word: Dict[int, str] = {}
+        self.table_pos_word_dist: Dict[int, float] = {}
+        self.table_neg_word_dist: Dict[int, float] = {}
+        self.table_hinge_loss: Dict[int, float] = {}
+    
+
+    def get_tracked_examples(self) -> None:
+        """Get information for sampled examples.  Called after dataloaders instantiated and before the training loop."""
+        for i in self.table_train_indices: self.table_split[i] = 'train'
+        for i in self.table_test_indices: self.table_split[i] = 'validation'
+        
+        for i in (self.table_train_indices+self.table_test_indices): 
+
+            # Pull sentence/overlap from dataset._para_tuples
+            pos_sent1, pos_sent2, token1, token2 = self.para_tuples[i] # (s1_id, s2_id, idx1, idx2)
+            pos_sent1, pos_sent2 = torch.tensor(self.id_to_sent[pos_sent1]), torch.tensor(self.id_to_sent[pos_sent2]) # convert sent_id to sentence tensor; shape: [40,50]
+            
+            pos_sent1_str, pos_sent2_str = elmo_sentence_decode(pos_sent1), elmo_sentence_decode(pos_sent2) # get string representations of sentence
+
+            # populate dictionaries
+            self.table_pos_sent1[i] = pos_sent1
+            self.table_pos_sent2[i] = pos_sent2
+            self.table_pos_sent1_str[i] = pos_sent1_str
+            self.table_pos_sent2_str[i] = pos_sent2_str
+            self.table_pos_word1[i] = token1
+            self.table_pos_word2[i] = token2
+            assert pos_sent1_str.split(' ')[token1] == pos_sent2_str.split(' ')[token2] # assert that the word is the same in both pos_sent1 & pos_sent2
+            self.table_pos_target_word[i] = pos_sent1_str.split(' ')[token1]
+
+    # TODO: called every time a batch is passed in the train/val loop from the respective dataloader
+    def check_tracked_indices(self, pos_sent_1: torch.Tensor, pos_sent_2: torch.Tensor,
+                              neg_sent_1: torch.Tensor, neg_sent_2: torch.Tensor,
+                              pos_token_1: torch.Tensor, pos_token_2: torch.Tensor,
+                              neg_token_1: torch.Tensor, neg_token_2: torch.Tensor) -> Dict[int,int]:
+        """Given a retrofit batch, determine if any of the examples are the ones we are sampling for a W&B Table.  """
+        
+        # Reset self.batch_indices each time it's called
+        self.batch_indices = {}
+        batch_size = pos_sent_1.shape[0]
+
+        # compare dictionary of sentences we're tracking to see if they're present in a batch.
+        for b in range(batch_size):
+            for i in self.table_pos_sent1.keys():
+                #  if sentence pair matches the paraphrase tuple, add batch_index as a value corresponding to the tracked_index key
+                if (torch.equal(self.table_pos_sent1[i], pos_sent_1[b]) and torch.equal(self.table_pos_sent2[i], pos_sent_2[b]) and 
+                    self.table_pos_word1[i] == pos_token_1[b].item() and self.table_pos_word2[i] == pos_token_2[b].item()):
+
+                    self.batch_indices[i] = b
+                    neg_sent1_str, neg_sent2_str = elmo_sentence_decode(neg_sent_1[b]), elmo_sentence_decode(neg_sent_2[b])
+                    self.table_neg_sent1_str[i] = neg_sent1_str
+                    self.table_neg_sent2_str[i] = neg_sent2_str
+                    self.table_neg_word1[i] = neg_token_1[b].item()
+                    self.table_neg_word2[i] = neg_token_2[b].item()
+                    assert neg_sent1_str.split(' ')[neg_token_1[b].item()] == neg_sent2_str.split(' ')[neg_token_2[b].item()] # assert that the word is the same in both pos_sent1 & pos_sent2
+                    self.table_neg_target_word[i] = neg_sent1_str.split(' ')[neg_token_1[b].item()]
+
+                else: continue
+
+        return self.batch_indices
+
+    def update_wandb_table(self, epoch:int) -> None:
+        """Update rows of example table at the end of each epoch."""
+        # columns ["index", "epoch", "positive/negative", "sent1", "sent2", "shared_word", "word_distance", "hinge_loss", "split"]
+        # columns [index, epoch, sent1, sent2, pos_word, positive, pos_distance, hinge_loss]
+        #         [index, epoch, sent1, sent2, neg_word, negative, neg_distance, hinge_loss] 
+        
+        # Each example will have 2 rows: Row A = Positive, Row B = Negative
+        for i in sorted(self.table_split.keys()):
+            # Row A
+            self.final_table.add_data(
+                i, epoch, 'positive', self.table_pos_sent1_str[i], self.table_pos_sent2_str[i],
+                self.table_pos_target_word[i], self.table_pos_word_dist[i],
+                self.table_hinge_loss[i], self.table_split[i]
+            )
+            # Row B
+            self.final_table.add_data(
+                i, epoch, 'negative', self.table_neg_sent1_str[i], self.table_neg_sent2_str[i],
+                self.table_neg_target_word[i], self.table_neg_word_dist[i],
+                self.table_hinge_loss[i], self.table_split[i]
+            )

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -53,7 +53,7 @@ class TestRetrofitLoss:
         a = torch.tensor([[1, 0, 1, 0]], dtype=float)
         b = torch.tensor([[0, 1, 0, 1]], dtype=float)
         assert self.experiment.retrofit_hinge_loss(
-            a, a, b, b, 0
+            a, a, b, b, 0, 0
         )[0] == 0.0 #js iterim test adjustment because `retrofit_hinge_loss` now returns a tuple of (hinge_loss, pre_clamp_hinge_loss)
     
     def test_retrofit_hinge_equal_dist(self):
@@ -62,8 +62,9 @@ class TestRetrofitLoss:
         a = torch.tensor([[1, 0, 1, 0]], dtype=float)
         b = torch.tensor([[0, 1, 0, 1]], dtype=float)
         gamma = 5.0
+        epoch = 1
         assert self.experiment.retrofit_hinge_loss(
-            a, b, a, b, gamma
+            a, b, a, b, gamma, epoch
         )[0] == gamma #js iterim test adjustment because `retrofit_hinge_loss` now returns a tuple of (hinge_loss, pre_clamp_hinge_loss)
     
     def test_retrofit_hinge_best_case_big_margin(self):
@@ -78,8 +79,9 @@ class TestRetrofitLoss:
         b1 = torch.tensor([[0, 100, 0, 100]], dtype=float)
         b2 = torch.tensor([[0, -100, 0, -100]], dtype=float) 
         gamma = 20.0
+        epoch = 1
         assert self.experiment.retrofit_hinge_loss(
-            a1, a2, b1, b2, gamma
+            a1, a2, b1, b2, gamma, epoch
         )[0] == 0.0 #js iterim test adjustment because `retrofit_hinge_loss` now returns a tuple of (hinge_loss, pre_clamp_hinge_loss)
     
     def test_retrofit_hinge_worst_case(self):
@@ -94,8 +96,9 @@ class TestRetrofitLoss:
         b1 = torch.tensor([[1, 0, 1, 0]], dtype=float)
         b2 = a1 + torch.rand_like(a1) / 100.0
         gamma = 10.0
+        epoch = 1
         loss = self.experiment.retrofit_hinge_loss(
-            a1, a2, b1, b2, gamma
+            a1, a2, b1, b2, gamma, epoch
         )[0] #js iterim test adjustment because `retrofit_hinge_loss` now returns a tuple of (hinge_loss, pre_clamp_hinge_loss)
         assert loss > gamma
     
@@ -114,7 +117,8 @@ class TestRetrofitLoss:
         b1 = torch.tensor([[1, 0, 1, 0], [1, 0, 1, 0]], dtype=float)
         b2 = a1 + torch.rand_like(a1) / 100.0
         gamma = 5.0
+        epoch = 1
         loss = self.experiment.retrofit_hinge_loss(
-            a1, a2, b1, b2, gamma
+            a1, a2, b1, b2, gamma, epoch
         )[0] #js iterim test adjustment because `retrofit_hinge_loss` now returns a tuple of (hinge_loss, pre_clamp_hinge_loss)
         assert loss > 50

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -9,7 +9,7 @@ class TestTableLog:
     def test_wb_table_final_data(self):
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         args = get_argparser().parse_args(
-                    ['retrofit', '--epochs', '1', '--num_examples', '6', '--batch_size', '2', '--random_seed','42', '--num_table_examples','1']#,'--num_table_examples','None']
+                    ['retrofit', '--epochs', '1', '--num_examples', '6', '--batch_size', '2', '--random_seed','42', '--num_table_examples','1']
                 )
         set_random_seed(args.random_seed)
         experiment = RetrofitExperiment(args)
@@ -57,10 +57,10 @@ class TestTableLog:
                 [0, 0, 'negative', 'What is the Lewis structure of PBR3 ? How is it determined ?', 'What is the Lewis structure for KrF2 ? How is it determined ?', 'structure', 'validation']
             ])
 
-            # check columns of table
+            # Check columns of table
             assert experiment.wb_table.final_table.columns == test_column_list
 
-            # check all columns that aren't tensors:
+            # Check all columns that aren't tensors:
             # ['epoch', 'index', 'positive/negative', 'sent1', 'sent2', 'shared_word', 'word_distance', 'hinge_loss', 'split']
             #    not 'word_distance' or 'hinge_loss'
             for i,data_row in enumerate(experiment.wb_table.final_table.data):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,0 +1,68 @@
+import torch
+import tqdm
+from experiment import RetrofitExperiment
+from train import get_argparser, set_random_seed
+
+
+class TestTableLog:
+
+    def test_wb_table_final_data(self):
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        args = get_argparser().parse_args(
+                    ['retrofit', '--epochs', '1', '--num_examples', '6', '--batch_size', '2', '--random_seed','42', '--num_table_examples','1']#,'--num_table_examples','None']
+                )
+        set_random_seed(args.random_seed)
+        experiment = RetrofitExperiment(args)
+
+        train_dataloader, test_dataloader= experiment.get_dataloaders()
+
+        ######### MIMICS RETROFIT TRAINING LOOP #########
+        # Given the argparse settings, there should be 4 examples for training, and 2 for testing.
+        # With `args.num_table_examples == 1`, there will be 4 rows in experiment.wb_table:
+        #     2 rows will correspond to the pos/neg case for the _training_ set
+        #     2 rows will correspond to the pos/neg case for the _test_ set
+        
+        for epoch in range(args.epochs):
+            for train_step, train_batch in tqdm.tqdm(enumerate(train_dataloader), total=len(train_dataloader), desc='Training', leave=False):
+                # Only save num_table_examples from first batch
+                if train_step == 0 and args.num_table_examples is not None:
+                    experiment.wb_table.get_sample_batch(epoch, experiment.model.training, *train_batch)
+
+                train_batch = (t.to(device) for t in train_batch)
+                word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(*train_batch)
+                experiment.compute_loss_and_update_metrics(epoch,word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Train')
+            
+            experiment.model.eval()
+            with torch.no_grad():
+                for test_step, test_batch in tqdm.tqdm(enumerate(test_dataloader), total=len(test_dataloader), desc='Evaluating', leave=False):
+                    # Only save num_table_examples from first batch
+                    if test_step == 0 and args.num_table_examples is not None:
+                        experiment.wb_table.get_sample_batch(epoch, experiment.model.training, *test_batch)
+                    
+                    test_batch = (t.to(device) for t in test_batch)
+                    word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(*test_batch)
+                    experiment.compute_loss_and_update_metrics(epoch,word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Test')
+        
+            experiment.model.train()
+            experiment.wb_table.update_wandb_table()
+
+        # Given a tiny number of total examples (6), and random seed of 42, these are the determined values in the table
+        #    I don't check the word distance or individual loss due to floating point error in checking tensors.
+        if experiment.wb_table is not None:
+            test_column_list = ['epoch', 'index', 'positive/negative', 'sent1', 'sent2', 'shared_word', 'word_distance', 'hinge_loss', 'split']
+            test_row_list = list([
+                [0, 0, 'positive', 'What are the best examples of the golden ratio in everyday life ?', 'Can you give some unknown examples of the golden ratio in our daily life that not everyone knows ?', 'life', 'train'],
+                [0, 0, 'negative', 'What is the Lewis structure of PBR3 ? How is it determined ?', 'What is the Lewis structure for KrF2 ? How is it determined ?', 'structure', 'train'],
+                [0, 0, 'positive', 'What are the best examples of the golden ratio in everyday life ?', 'Can you give some unknown examples of the golden ratio in our daily life that not everyone knows ?', 'golden', 'validation'],
+                [0, 0, 'negative', 'What is the Lewis structure of PBR3 ? How is it determined ?', 'What is the Lewis structure for KrF2 ? How is it determined ?', 'structure', 'validation']
+            ])
+
+            # check columns of table
+            assert experiment.wb_table.final_table.columns == test_column_list
+
+            # check all columns that aren't tensors:
+            # ['epoch', 'index', 'positive/negative', 'sent1', 'sent2', 'shared_word', 'word_distance', 'hinge_loss', 'split']
+            #    not 'word_distance' or 'hinge_loss'
+            for i,data_row in enumerate(experiment.wb_table.final_table.data):
+                assert data_row[:6] == test_row_list[i][:6]
+                assert data_row[-1] == test_row_list[i][-1]

--- a/train.py
+++ b/train.py
@@ -234,7 +234,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
                         if args.experiment == 'finetune':
                             if len(batch) == 2: # single-sentence classification
                                 sentence, targets = batch
-                                sentence, targets = sentence.to(device), targets.to(device) # TODO(js) retrofit_change
+                                sentence, targets = sentence.to(device), targets.to(device)
                                 preds = experiment.model(sentence)
                             elif len(batch) == 3: # sentence-pair classification
                                 sentence1, sentence2, targets = batch

--- a/train.py
+++ b/train.py
@@ -256,7 +256,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
                             experiment.compute_loss_and_update_metrics(preds, targets, 'Test')
                         else:
                             # if first batch, log examples for W&B table
-                            if _epoch_step == 0 and args.num_table_examples is not None:
+                            if _test_step == 0 and args.num_table_examples is not None:
                                 experiment.wb_table.get_sample_batch(epoch, experiment.model.training, *batch)
                             # sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
                             batch = (t.to(device) for t in batch)

--- a/train.py
+++ b/train.py
@@ -60,7 +60,7 @@ def get_argparser() -> argparse.ArgumentParser:
         help='lambda - regularization constant for retrofitting loss')
     parser.add_argument('--rf_gamma', type=float, default=2,
         help='gamma - margin constant for retrofitting loss')
-    parser.add_argument('--num_table_examples', type=int, default=2,
+    parser.add_argument('--num_table_examples', type=int, default=None,
         help='examples to watch in both train/test sets - will log to W&B Table')
 
     # for these boolean arguments, append the flag if you want it to be `True`
@@ -98,6 +98,10 @@ def run_training_loop(args: argparse.Namespace) -> str:
         logger.warn("Batch size (%d) cannot be greater than num examples (%d), decreasing batch size", args.batch_size, args.num_examples)
         args.batch_size = args.num_examples
     
+    if (args.num_table_examples is not None) and (args.num_table_examples > args.batch_size):
+        logger.warn("Batch size (%d) cannot be greater than num table examples (%d), decreasing num table examples", args.batch_size, args.num_table_examples)
+        args.num_table_examples = args.batch_size
+
     # dictionary that matches experiment argument to its respective class
     experiment_cls = {
         'retrofit': RetrofitExperiment,
@@ -218,12 +222,13 @@ def run_training_loop(args: argparse.Namespace) -> str:
                     raise ValueError(f'Expected batch of length 2 or 3, got {len(batch)}')
                 train_loss = experiment.compute_loss_and_update_metrics(preds, targets, 'Train')
             else:
-                # Check to see if sampled examples are in the batch
-                experiment.wb_table.check_tracked_indices(*batch)
+                # if first batch, log examples for W&B table
+                if _epoch_step == 0 and args.num_table_examples is not None:
+                    experiment.wb_table.get_sample_batch(epoch, experiment.model.training, *batch)
                 # sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
                 batch = (t.to(device) for t in batch)
                 word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(*batch)
-                train_loss = experiment.compute_loss_and_update_metrics(word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Train')
+                train_loss = experiment.compute_loss_and_update_metrics(epoch, word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Train')
             
             train_loss.backward()
             optimizer.step()
@@ -234,7 +239,7 @@ def run_training_loop(args: argparse.Namespace) -> str:
                 experiment.model.eval() # set model in eval mode for evaluation
                 # Compute eval metrics every `log_interval` batches
                 with torch.no_grad():
-                    for batch in tqdm.tqdm(test_dataloader, total=len(test_dataloader), desc='Evaluating', leave=False):
+                    for _test_step, batch in tqdm.tqdm(enumerate(test_dataloader), total=len(test_dataloader), desc='Evaluating', leave=False):
                         if args.experiment == 'finetune':
                             if len(batch) == 2: # single-sentence classification
                                 sentence, targets = batch
@@ -250,12 +255,13 @@ def run_training_loop(args: argparse.Namespace) -> str:
                                 raise ValueError(f'Expected batch of length 2 or 3, got {len(batch)}')
                             experiment.compute_loss_and_update_metrics(preds, targets, 'Test')
                         else:
-                            # Check to see if sampled examples are in the batch
-                            experiment.wb_table.check_tracked_indices(*batch)
+                            # if first batch, log examples for W&B table
+                            if _epoch_step == 0 and args.num_table_examples is not None:
+                                experiment.wb_table.get_sample_batch(epoch, experiment.model.training, *batch)
                             # sent1, sent2, nsent1, nsent2, token1, token2, ntoken1, ntoken2 = batch
                             batch = (t.to(device) for t in batch)
                             word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2 = experiment.model(*batch) 
-                            experiment.compute_loss_and_update_metrics(word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Test')
+                            experiment.compute_loss_and_update_metrics(epoch,word_rep_pos_1, word_rep_pos_2, word_rep_neg_1, word_rep_neg_2, 'Test')
                 # Compute metrics, log, and reset
                 metrics_dict = experiment.compute_and_reset_metrics(training_step, epoch)
                 wandb.log(metrics_dict, step=training_step)
@@ -279,15 +285,14 @@ def run_training_loop(args: argparse.Namespace) -> str:
         epoch_end_time = time.time()
         logger.info(f"\nEpoch {epoch+1}/{args.epochs} Total EPOCH Time: {(epoch_end_time-epoch_start_time)/60:>0.2f} min")
         wandb.log({"Epoch Time": (epoch_end_time-epoch_start_time)/60})
-        if args.experiment == 'retrofit':
-            experiment.wb_table.update_wandb_table(epoch+1)
 
         epoch_start_time = time.time()
 
     logging.info(f'***** Training finished after {args.epochs} epochs *****')
 
     # After training, log example table
-    if args.experiment == 'retrofit':
+    if args.experiment == 'retrofit' and args.num_table_examples is not None:
+        experiment.wb_table.update_wandb_table()
         wandb.log({'sampled_examples_table':experiment.wb_table.final_table}) 
 
     # Save final model

--- a/train.py
+++ b/train.py
@@ -282,12 +282,13 @@ def run_training_loop(args: argparse.Namespace) -> str:
         if args.experiment == 'retrofit':
             experiment.wb_table.update_wandb_table(epoch+1)
 
-            # TODO(js): if you log it every epoch will it continue to append new rows, or completely reset the table?
-            # https://docs.wandb.ai/guides/data-vis/log-tables#log-a-table-to-a-run
-            wandb.log({'sampled_examples_table':experiment.wb_table.final_table}) 
-
         epoch_start_time = time.time()
+
     logging.info(f'***** Training finished after {args.epochs} epochs *****')
+
+    # After training, log example table
+    if args.experiment == 'retrofit':
+        wandb.log({'sampled_examples_table':experiment.wb_table.final_table}) 
 
     # Save final model
     final_save_path = os.path.join(

--- a/utils.py
+++ b/utils.py
@@ -53,3 +53,37 @@ def log_wandb_histogram(list_of_values: list, description: str, step: int, epoch
             'epoch': epoch,
             'step': step
     })
+
+
+
+def elmo_sentence_decode(sent: torch.Tensor) -> str:
+    """
+    Decodes a sentence of ELMo character_ids with the shape [1,sequence_length,50] into a readable sentence string.
+    Useful for debugging when you only have a ParaDatasetElmo object and its various tensor/tuple/sent_id returns.
+    """
+    sent = tuple([tuple(word.tolist()) for word in sent.squeeze()])
+    full_sent = []
+    for word in sent:
+        if word == tuple([0]*50): continue
+        word_concat = []
+        for char in word:
+            # print(char)
+            if char == 259: continue
+            if char == 260: break
+            if char == 261: break
+            word_concat.append(chr(char-1))
+        full_sent.append(''.join(word_concat))
+    return ' '.join(full_sent)
+
+def elmo_word_decode(word: Tuple) -> str:
+    """
+    Decodes a word tuple of ELMo character_ids with length=50 into a readable sentence string.
+    Useful for debugging when you only have a ParaDatasetElmo object and its various tensor/tuple/sent_id returns.
+    """
+    word_concat = []
+    for char in word:
+        if char == 259: continue
+        if char == 260: break
+        word_concat.append(chr(char-1))
+
+    return ''.join(word_concat)

--- a/utils.py
+++ b/utils.py
@@ -60,19 +60,27 @@ def elmo_sentence_decode(sent: torch.Tensor) -> str:
     """
     Decodes a sentence of ELMo character_ids with the shape [1,sequence_length,50] into a readable sentence string.
     Useful for debugging when you only have a ParaDatasetElmo object and its various tensor/tuple/sent_id returns.
+
+    - 259 is the beginning of word character
+    - 260 is the end of word character
+    - 261 is the padding character
+
+    From [AllenNLP's ELMo Tokenizer]
+    (https://github.com/allenai/allennlp/blob/b8f92f036e37015aabe0d76aabf2722597c7686f/allennlp/data/token_indexers/elmo_indexer.py#L38-L44) 
+    "char ids 0-255 come from utf-8 encoding bytes."  Based on trial and error, for some reason, the values are off by 1.  
+    Example: 260 should be the "padding character", but in reality it's 261.
     """
     sent = tuple([tuple(word.tolist()) for word in sent.squeeze()])
     full_sent = []
     for word in sent:
         if word == tuple([0]*50): continue
-        word_concat = []
+        chars_in_word = []
         for char in word:
-            # print(char)
-            if char == 259: continue
-            if char == 260: break
-            if char == 261: break
-            word_concat.append(chr(char-1))
-        full_sent.append(''.join(word_concat))
+            if char == 259: continue # beginning of word character
+            if char == 260: break    # end of word character
+            if char == 261: break    # padding character
+            chars_in_word.append(chr(char-1))
+        full_sent.append(''.join(chars_in_word))
     return ' '.join(full_sent)
 
 def elmo_word_decode(word: Tuple) -> str:
@@ -80,10 +88,10 @@ def elmo_word_decode(word: Tuple) -> str:
     Decodes a word tuple of ELMo character_ids with length=50 into a readable sentence string.
     Useful for debugging when you only have a ParaDatasetElmo object and its various tensor/tuple/sent_id returns.
     """
-    word_concat = []
+    chars_in_word = []
     for char in word:
-        if char == 259: continue
-        if char == 260: break
-        word_concat.append(chr(char-1))
+        if char == 259: continue # beginning of word character
+        if char == 260: break    # end of word character
+        chars_in_word.append(chr(char-1))
 
-    return ''.join(word_concat)
+    return ''.join(chars_in_word)


### PR DESCRIPTION
## Thus far:

- [x] added `elmo_sentence_decode` and `elmo_word_decode` to `utils.py`; allows you to turn an ELMo sentence tensor into a readable string
- [x] made `wb_table: TableLog` an attribute of `RetrofitExperiment`, 
- [x] modified `retrofit_hinge_loss` to update internal dictionary attributes with the hinge loss, pos_word_dist, neg_word_dist; 
- [x] make sure the table lists the positive/negative example index (for grouping pos/neg examples in a given epoch/split)
- [x]  loop over final dictionaries at end of training--> `update_wandb_table()`
- [x] ensured the table logs each epoch; total number of rows should be `num_table_examples` * 4 * `epochs` (4 because pos/neg for each example and train/val examples)
- [x] addressed time complexity issue
- [x] added test coverage for `TableLog`
- [ ] address the "minor improvement"