### PR TITLE
Random sampler to fix

### DIFF
--- a/dataloaders/helpers.py
+++ b/dataloaders/helpers.py
@@ -1,6 +1,8 @@
 from typing import Callable, List, Tuple
 
 import collections
+import os
+
 import datasets
 import numpy as np
 import torch
@@ -9,6 +11,9 @@ from allennlp.modules.elmo import batch_to_ids
 from mosestokenizer import MosesTokenizer
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.sampler import SubsetRandomSampler
+
+
+num_cpus = len(os.sched_getaffinity(0)) # ask the OS how many cpus we have (stackoverflow.com/questions/1006289)
 
 def train_test_split(dataset: Dataset, batch_size: int, shuffle: bool = True, 
                      drop_last: bool = False, train_split: float = 0.8) -> Tuple[DataLoader, DataLoader]:
@@ -87,7 +92,8 @@ def dataloader_from_dataset(
         return tuple(torch.stack(d[k]) for k in text_columns) + tuple(torch.stack(d[k]).float() for k in label_columns)
     return DataLoader(dataset,
         batch_size=batch_size, collate_fn=collate_fn,
-        shuffle=shuffle, drop_last=drop_last, pin_memory=True
+        shuffle=shuffle, drop_last=drop_last, pin_memory=torch.cuda.is_available(),
+        num_workers=min(8, num_cpus)
     )
 
 

--- a/dataloaders/helpers.py
+++ b/dataloaders/helpers.py
@@ -63,8 +63,7 @@ def prepare_dataset_with_elmo_tokenizer(dataset, text_columns: List[str], max_le
 
     # Caching sometimes causes weird issues with .map(), if you see that then
     # add the load_from_cache_file=False argument below.
-    dataset = dataset.map(text_to_ids, batched=False, load_from_cache_file=False)
-    return dataset
+    return dataset.map(text_to_ids, batched=False)
 
 
 def dataloader_from_dataset(
@@ -88,7 +87,7 @@ def dataloader_from_dataset(
         return tuple(torch.stack(d[k]) for k in text_columns) + tuple(torch.stack(d[k]).float() for k in label_columns)
     return DataLoader(dataset,
         batch_size=batch_size, collate_fn=collate_fn,
-        shuffle=True, drop_last=drop_last, pin_memory=True
+        shuffle=shuffle, drop_last=drop_last, pin_memory=True
     )
 
 
@@ -131,7 +130,11 @@ def load_qqp(
         for split in dataset:
             dataset[split] = datasets.Dataset.from_dict(dataset[split][:num_examples])
 
-    dataset = prepare_dataset_with_elmo_tokenizer(dataset=dataset, text_columns=['question1', 'question2'], max_length=max_length)
+    dataset = prepare_dataset_with_elmo_tokenizer(
+        dataset=dataset,
+        text_columns=['question1', 'question2'],
+        max_length=max_length
+    )
     train_dataset, test_dataset = dataset['train'], dataset['validation'] # 'test' set has no labels, so it's not useful for us
 
     print('Loading rotten tomatoes dataset with', num_examples, 'examples')

--- a/dataloaders/helpers.py
+++ b/dataloaders/helpers.py
@@ -1,6 +1,7 @@
 from typing import Callable, List, Tuple
 
 import collections
+import logging
 import os
 
 import datasets
@@ -12,6 +13,7 @@ from mosestokenizer import MosesTokenizer
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.data.sampler import SubsetRandomSampler
 
+logger = logging.getLogger(__name__)
 
 num_cpus = len(os.sched_getaffinity(0)) # ask the OS how many cpus we have (stackoverflow.com/questions/1006289)
 
@@ -82,6 +84,7 @@ def dataloader_from_dataset(
     def collate_fn(batch):
         """`batch` is a list with `batch_size` elements. Each element is a dict with
         `label` and `text_ids` keys."""
+        # TODO(jxm): This is super slow; speed up this function.
         d = collections.defaultdict(list)
         for el in batch:
             for k in text_columns:
@@ -111,6 +114,8 @@ def load_rotten_tomatoes(
     dataset = prepare_dataset_with_elmo_tokenizer(dataset=dataset, text_columns=['text'], max_length=max_length)
     # TODO: support arbitrary tokenizer (for any model)
     train_dataset, test_dataset = dataset['train'], dataset['test'] # rt also has a 'validation' set
+
+    logger.info('Loading Rotten Tomatoes dataset with %d examples', len(train_dataset))
 
     train_dataset.set_format(type='torch', columns=['text', 'label'])
     test_dataset.set_format(type='torch', columns=['text', 'label'])
@@ -143,7 +148,7 @@ def load_sst2(
     )
     train_dataset, test_dataset = dataset['train'], dataset['validation'] # 'test' set has no labels, so it's not useful for us
 
-    print('Loading QQP dataset with', num_examples, 'examples')
+    logger.info('Loading SST-2 dataset with %d examples', len(train_dataset))
 
     train_dataset.set_format(type='torch', columns=['sentence', 'label'])
     test_dataset.set_format(type='torch', columns=['sentence', 'label'])
@@ -156,7 +161,6 @@ def load_sst2(
         dataset=test_dataset, text_columns=['sentence'], label_columns=['label'],
         batch_size=batch_size, shuffle=True, drop_last=drop_last
     )
-    breakpoint()
     return train_dataloader, test_dataloader
 
 
@@ -177,7 +181,7 @@ def load_qqp(
     )
     train_dataset, test_dataset = dataset['train'], dataset['validation'] # 'test' set has no labels, so it's not useful for us
 
-    print('Loading QQP dataset with', num_examples, 'examples')
+    logger.info('Loading QQP dataset with %d examples', len(train_dataset))
 
     train_dataset.set_format(type='torch', columns=['question1', 'question2', 'label'])
     test_dataset.set_format(type='torch', columns=['question1', 'question2', 'label'])

--- a/experiment.py
+++ b/experiment.py
@@ -8,7 +8,9 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from dataloaders import ParaphraseDatasetElmo
-from dataloaders.helpers import load_rotten_tomatoes, load_qqp, train_test_split
+from dataloaders.helpers import (
+    load_rotten_tomatoes, load_qqp, load_sst2, train_test_split
+)
 from metrics import Metric, Accuracy, PrecisionRecallF1
 from models import ElmoClassifier, ElmoRetrofit
 from utils import TensorRunningAverages, log_wandb_histogram
@@ -279,6 +281,12 @@ class FinetuneExperiment(Experiment):
             )
         elif self.args.dataset_name == 'rotten_tomatoes':
             train_dataloader, test_dataloader = load_rotten_tomatoes(
+                max_length=self.args.max_length, batch_size=self.args.batch_size,
+                num_examples=self.args.num_examples, drop_last=self.args.drop_last,
+                random_seed=self.args.random_seed
+            )
+        elif self.args.dataset_name == 'sst2':
+            train_dataloader, test_dataloader = load_sst2(
                 max_length=self.args.max_length, batch_size=self.args.batch_size,
                 num_examples=self.args.num_examples, drop_last=self.args.drop_last,
                 random_seed=self.args.random_seed

--- a/models.py
+++ b/models.py
@@ -191,7 +191,6 @@ class ElmoRetrofit(torch.nn.Module):
         """
 
         batch_size = pos_sent_1.shape[0] # batch_size because drop_last = False
-
         
         assert pos_sent_1.shape == pos_sent_2.shape == (batch_size,40,50)
         assert neg_sent_1.shape == neg_sent_2.shape == (batch_size,40,50)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,7 @@ import torch
 from dataloaders import ParaphraseDatasetBert, ParaphraseDatasetElmo
 from mosestokenizer import MosesTokenizer
 
-from dataloaders.helpers import load_rotten_tomatoes, load_qqp, train_test_split
+from dataloaders.helpers import load_rotten_tomatoes, load_qqp, load_sst2, train_test_split
 
 # Instantiate ParaphraseDataset class variants for BERT and ELMo
 
@@ -190,5 +190,20 @@ class TestClassificationDatasets:
         # Make sure sentences are the proper shape
         assert s1.shape == (batch_size, max_length, 50)
         assert s2.shape == (batch_size, max_length, 50)
+        # make sure all labels in batch are in {0, 1}
+        assert torch.logical_or(labels == 0, labels == 1).all()
+    
+    def test_sst2_elmo(self):
+        batch_size = 17
+        num_examples = 50
+        max_length = 20
+        train_dataloader, test_dataloader = load_sst2(
+            batch_size=batch_size, max_length=max_length,
+            num_examples=num_examples, drop_last=False
+        )
+        item = next(iter(train_dataloader))
+        s1, labels = item
+        # Make sure sentences are the proper shape
+        assert s1.shape == (batch_size, max_length, 50)
         # make sure all labels in batch are in {0, 1}
         assert torch.logical_or(labels == 0, labels == 1).all()

--- a/train.py
+++ b/train.py
@@ -51,7 +51,7 @@ def get_argparser() -> argparse.ArgumentParser:
     parser.add_argument('--model_name', type=str, default='elmo_single_sentence', 
         choices=['elmo_single_sentence', 'elmo_sentence_pair'], help='name of model to use')
     parser.add_argument('--dataset_name', type=str, default='qqp', 
-        choices=['qqp', 'rotten_tomatoes'], help='name of dataset to use for finetuning')
+        choices=['qqp', 'rotten_tomatoes', 'sst2'], help='name of dataset to use for finetuning')
     parser.add_argument('--model_weights', type=str, default=None,
         help='path to model weights to load, like `models/something.pth`')
     parser.add_argument('--batch_size', type=int, default=256)


### PR DESCRIPTION
Random sampling *with* replacement seems to fix the sawtooth shape we saw in the loss, especially on fine-tuning QQP.

See PyTorch forum post: [Observing strange loss jumps between epochs](https://discuss.pytorch.org/t/observing-strange-loss-jumps-between-epochs/64066)[](https://discuss.pytorch.org/c/vision/5)

Builds on #23 
